### PR TITLE
Update ps2exe.ps1 to use `$PSScriptRoot` instead of `$MyInvocation.MyCommand.Name`

### DIFF
--- a/Module/ps2exe.ps1
+++ b/Module/ps2exe.ps1
@@ -200,7 +200,7 @@ function Invoke-ps2exe
 
 		$CallParam += " -nested"
 
-		powershell -Command "&'$($MyInvocation.MyCommand.Name)' $CallParam"
+		powershell -Command "&'$PSScriptRoot\ps2exe.ps1' $CallParam"
 		return
 	}
 

--- a/Module/ps2exe.ps1
+++ b/Module/ps2exe.ps1
@@ -2798,3 +2798,8 @@ $(if (!$noConsole) {@"
 		}
 	}
 }
+
+# if this file is called directly, execute the function
+if ($args) {
+	Invoke-ps2exe @args
+}


### PR DESCRIPTION
This will fix the problem of not being able to use the module in pwsh without installing it in winpwsh.